### PR TITLE
Removes unnecessary logging for each replacement

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ var editFile = function(file, options) {
          var nodes = select(query, doc);
          nodes.forEach(function(node){
             var value = getValue(node);
-            gutil.log('setting value of "' + query + '" to "' + value +'"');                  
             if(valueType === 'element') {                     
                node.textContent = '';
                while(node.firstChild){


### PR DESCRIPTION
It's a little bit oververbose to see every value being changed. I mean, the gulp developer explicitly set it: they don't need to see it _every time they build_, right?

I could add a `quiet` flag to the options, but I'd rather follow the convention of quietly doing the work and only filling the console when there's an error
